### PR TITLE
feat: Add support for customizing zIndex of the Toasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Because of the theming capability of `react-native-styled-toast`, it has out of 
 | **`maxToasts`** | number | no       | Sets max number of toasts to show              | Constants.statusBarHeight |
 | **`offset`**    | number | no       | Increases default offset from the top / bottom | Constants.statusBarHeight |
 | **`position`**  | enum   | no       | Sets the position of the toasts                | TOP                       |
+| **`zIndex`**    | number | no       | Sets the zIndex of the toasts                  | 1                         |
 
 ### `ToastConfig`
 

--- a/src/Context/index.tsx
+++ b/src/Context/index.tsx
@@ -11,6 +11,7 @@ type ToastContextType = {
   position?: 'TOP' | 'BOTTOM'
   offset?: number
   maxToasts?: number
+  zIndex?: number
 }
 
 export const ToastContext = React.createContext<ToastContextType>({
@@ -44,7 +45,8 @@ const ToastProvider: React.FC<Omit<ToastContextType, 'toast'>> = ({
   children,
   position,
   offset: offsetProp,
-  maxToasts
+  maxToasts,
+  zIndex = 1
 }) => {
   const [toasts, setToasts] = React.useState<FullToastConfig[]>([])
 
@@ -78,6 +80,7 @@ const ToastProvider: React.FC<Omit<ToastContextType, 'toast'>> = ({
     <ToastContext.Provider value={{ toast }}>
       {children}
       <Box
+        zIndex={zIndex}
         px={4}
         left={0}
         right={0}


### PR DESCRIPTION
# Summary

First of all, thank you for publishing this fantastic package! It has worked great for our use case so far.

This PR adds support for customizing the `zIndex` property of the toasts so that they can be displayed on top of other components.

# Motivation

The motivation for this is that our project uses [react-native-reanimated-bottom-sheet](https://github.com/osdnk/react-native-reanimated-bottom-sheet) and we want the ability to display toasts on top of the bottom sheet when it is open. When I tested this, it did not work. However, adding the zIndex property allowed it to work. I would guess there are other scenarios where it would be useful to customize `zIndex` as well.

This PR keeps zIndex as optional with a default of 1. That way anyone who doesn't need it can ignore it, and anyone who needs the customization has the option.

# Testing

I tested this locally in our project and it works as intended. Unfortunately, I am unable to get the project tests to run locally with `yarn test` (even on the `develop` branch with no changes). If you know how I can fix that, please let me know. I'd be happy to run tests locally to make sure this doesn't break anything.

If there is anything I can do to improve this PR to ensure it gets merged, please let me know. Thanks again for your work on this package.